### PR TITLE
fix: Resolve memory leaks in C++/Fortran interface

### DIFF
--- a/.github/workflows/matrix_config.yml
+++ b/.github/workflows/matrix_config.yml
@@ -27,14 +27,6 @@ jobs:
                 "coverage": false
               },
               {
-                "name": "macOS 13 Clang",
-                "os": "macos-13",
-                "cc": "clang",
-                "cxx": "clang++",
-                "fort": "gfortran",
-                "coverage": false
-              },
-              {
                 "name": "macOS 14 Clang",
                 "os": "macos-14",
                 "cc": "clang",

--- a/src/Achilles/fortran/FMap.cc
+++ b/src/Achilles/fortran/FMap.cc
@@ -42,19 +42,6 @@ void map_delete(std::map<std::string, double> *map) {
     delete map;
 }
 
-struct complex {
-    double real;
-    double imag;
-
-#ifdef __cplusplus
-    complex() : real(0.0), imag(0.0) {}
-    complex(double r) : real(r), imag(0.0) {}
-    complex(double r, double i) : real(r), imag(i) {}
-    complex(std::complex<double> c) : real(c.real()), imag(c.imag()) {}
-    operator std::complex<double>() const { return std::complex<double>(real, imag); }
-#endif
-};
-
 void cmap_init(std::map<std::string, std::complex<double>> *&map) {
     map = new std::map<std::string, std::complex<double>>();
 }
@@ -64,13 +51,14 @@ void cmap_insert(std::map<std::string, std::complex<double>> *map, const char *k
     map->insert({std::string(key), value});
 }
 
-complex *cmap_lookup(std::map<std::string, std::complex<double>> *map, const char *key) {
+void cmap_lookup(std::map<std::string, std::complex<double>> *map, const char *key,
+                 std::complex<double> *outval) {
     std::string skey(key);
-    if(map->find(skey) == map->end()) {
-        complex *c = new complex();
-        return c;
+    auto it = map->find(skey);
+    if(it == map->end()) {
+        *outval = std::complex<double>();
     } else {
-        return new complex((*map)[skey]);
+        *outval = it->second;
     }
 }
 

--- a/src/Achilles/fortran/intf_spectral_model.f90
+++ b/src/Achilles/fortran/intf_spectral_model.f90
@@ -226,6 +226,18 @@ contains
               cur(i+2*(j-1),:)=J_mu(j,i,:)
             enddo   
         enddo
+
+     ! Clean up memory
+     call qvec%delete()
+     do i=1,nin
+        call mom_in(i)%delete()
+     enddo
+     do i=1,nout
+        call mom_out(i)%delete()
+     enddo
+     do i=1,nspect
+        call mom_spect(i)%delete()
+     enddo
      return
     end subroutine
 
@@ -241,6 +253,7 @@ contains
         integer(c_long), dimension(nspect), intent(in) :: pids_spect
         integer(c_size_t), intent(in), value :: nin, nspect, nproton, nneutron
         double precision, dimension(4) :: p1_4,p2_4
+        integer(c_size_t) :: i
         real(c_double) :: wgt, pmom,pspec_mom,E, hole_wgt, spect_wgt
 
         p1_4=mom_in(1)%to_array()
@@ -264,6 +277,13 @@ contains
 
         wgt = hole_wgt * spect_wgt
 
+        ! Clean up memory
+        do i=1,nin
+           call mom_in(i)%delete()
+        enddo
+        do i=1,nspect
+           call mom_spect(i)%delete()
+        enddo
     end function intf_spec_init_wgt
 
 

--- a/src/Achilles/fortran/map_mod.f90
+++ b/src/Achilles/fortran/map_mod.f90
@@ -112,13 +112,13 @@ module libmap
             complex(kind=c_double_complex), intent(in), value :: val
         end subroutine ccmap_insert
 
-        function ccmap_lookup(dict, key) result(val) bind(C, name="cmap_lookup")
+        subroutine ccmap_lookup(dict, key, val) bind(C, name="cmap_lookup")
             use iso_c_binding
             implicit none
             type(c_ptr), value :: dict
             type(c_ptr), intent(in), value :: key
-            complex(kind=c_double_complex), pointer :: val
-        end function ccmap_lookup
+            complex(kind=c_double_complex), intent(out) :: val
+        end subroutine ccmap_lookup
 
         function ccmap_contains(dict, key) result(val) bind(C, name="cmap_contains")
             use iso_c_binding
@@ -184,6 +184,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         call cmap_insert(this%dict, ckey, val)
+        call free(ckey)
     end subroutine map_insert
 
     function map_lookup(this, key) result(val)
@@ -196,6 +197,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         val = cmap_lookup(this%dict, ckey)
+        call free(ckey)
     end function map_lookup
 
     function map_contains(this, key) result(val)
@@ -208,6 +210,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         val = cmap_contains(this%dict, ckey)
+        call free(ckey)
     end function map_contains
 
     function map_empty(this) result(val)
@@ -226,6 +229,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         call cmap_erase(this%dict, ckey)
+        call free(ckey)
     end subroutine map_erase
 
     subroutine map_clear(this)
@@ -265,6 +269,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         call ccmap_insert(this%dict, ckey, val)
+        call free(ckey)
     end subroutine complex_map_insert
 
     function complex_map_lookup(this, key) result(val)
@@ -276,7 +281,8 @@ contains
         type(c_ptr) :: ckey
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
-        val = ccmap_lookup(this%dict, ckey)
+        call ccmap_lookup(this%dict, ckey, val)
+        call free(ckey)
     end function complex_map_lookup
 
     function complex_map_contains(this, key) result(val)
@@ -289,6 +295,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         val = ccmap_contains(this%dict, ckey)
+        call free(ckey)
     end function complex_map_contains
 
     function complex_map_empty(this) result(val)
@@ -306,6 +313,7 @@ contains
         trim_key = trim(key) 
         ckey = f2cstring(trim_key)
         call ccmap_erase(this%dict, ckey)
+        call free(ckey)
     end subroutine complex_map_erase
 
     subroutine complex_map_clear(this)

--- a/src/Achilles/fortran/qe_spectral_model.f90
+++ b/src/Achilles/fortran/qe_spectral_model.f90
@@ -134,6 +134,18 @@ contains
               cur(i+2*(j-1),:) = J_mu(j,i,:)
             enddo   
         enddo
+
+     ! Clean up memory
+     call qvec%delete()
+     do i=1,nin
+        call mom_in(i)%delete()
+     enddo
+     do i=1,nout
+        call mom_out(i)%delete()
+     enddo
+     do i=1,nspect
+        call mom_spect(i)%delete()
+     enddo
      return
     end subroutine
 
@@ -149,6 +161,7 @@ contains
         integer(c_long), dimension(nspect), intent(in) :: pids_spect
         integer(c_size_t), intent(in), value :: nin, nspect, nproton, nneutron
         double precision, dimension(4) :: p4
+        integer(c_size_t) :: i
         real(c_double) :: wgt, pmom, E
 
         p4=mom_in(1)%to_array()
@@ -160,6 +173,14 @@ contains
         else
             wgt=nneutron*spectral_n%call(pmom,E)
         endif
+
+        ! Clean up memory
+        do i=1,nin
+           call mom_in(i)%delete()
+        enddo
+        do i=1,nspect
+           call mom_spect(i)%delete()
+        enddo
         
     end function qe_spec_init_wgt
 end module qe_spectral_model

--- a/src/Achilles/fortran/res_spectral_model.f90
+++ b/src/Achilles/fortran/res_spectral_model.f90
@@ -147,6 +147,18 @@ contains
               cur(i+2*(j-1),:)= coupling*J_mu(j,i,:)
             enddo   
         enddo
+
+     ! Clean up memory
+     call qvec%delete()
+     do i=1,nin
+        call mom_in(i)%delete()
+     enddo
+     do i=1,nout
+        call mom_out(i)%delete()
+     enddo
+     do i=1,nspect
+        call mom_spect(i)%delete()
+     enddo
      return
     end subroutine
 
@@ -162,6 +174,7 @@ contains
         integer(c_long), dimension(nspect), intent(in) :: pids_spect
         integer(c_size_t), intent(in), value :: nin, nspect, nproton, nneutron
         double precision, dimension(4) :: p4
+        integer(c_size_t) :: i
         real(c_double) :: wgt, pmom, E
 
         p4=mom_in(1)%to_array()
@@ -173,5 +186,13 @@ contains
         else
             wgt=nneutron*spectral_n%call(pmom,E)
         endif
+
+        ! Clean up memory
+        do i=1,nin
+           call mom_in(i)%delete()
+        enddo
+        do i=1,nspect
+           call mom_spect(i)%delete()
+        enddo
     end function res_spec_init_wgt
 end module res_spectral_model

--- a/src/Achilles/fortran/spectral_function_mod.f90
+++ b/src/Achilles/fortran/spectral_function_mod.f90
@@ -32,6 +32,7 @@ contains
 
         cfilename = f2cstring(filename)
         create_spectral%ptr = create_spectral_function_c(cfilename)
+        call free(cfilename)
     end function
 
     subroutine delete_spectral(self)

--- a/src/Achilles/fortran/vectors_mod.f90
+++ b/src/Achilles/fortran/vectors_mod.f90
@@ -21,6 +21,7 @@ module libvectors
         procedure :: get => get4
         procedure :: print => print4
         procedure :: to_array => array4
+        procedure :: delete => delete_fourvector
     end type fourvector
 
     ! This will act as constructor
@@ -42,6 +43,7 @@ module libvectors
         procedure :: get => get3
         procedure :: print => print3
         procedure :: copy => new3
+        procedure :: delete => delete_threevector
     end type threevector
 
     ! This will act as constructor
@@ -90,8 +92,11 @@ contains ! Implementation of functions
 
     subroutine delete_fourvector(this)
         implicit none
-        type(fourvector) :: this
-        call delete_fourvector_c(this%ptr)
+        class(fourvector) :: this
+        if(c_associated(this%ptr)) then
+            call delete_fourvector_c(this%ptr)
+            this%ptr = c_null_ptr
+        end if
     end subroutine
 
     function get_ptr4(this)
@@ -222,8 +227,11 @@ contains ! Implementation of functions
 
     subroutine delete_threevector(this)
         implicit none
-        type(threevector) :: this
-        call delete_threevector_c(this%ptr)
+        class(threevector) :: this
+        if(c_associated(this%ptr)) then
+            call delete_threevector_c(this%ptr)
+            this%ptr = c_null_ptr
+        end if
     end subroutine
 
     function get_ptr3(this)

--- a/test/test_fortran_interference.f90
+++ b/test/test_fortran_interference.f90
@@ -207,8 +207,12 @@ contains
         mom_spect = fourvector(p2_4(1), p2_4(2), p2_4(3), p2_4(4))
         qvec = fourvector(q4(1), q4(2), q4(3), q4(4))
 
-
         call model%currents(pids_in, mom_in, nin, pids_out, mom_out, nout, pids_spect, mom_spect, nspect, qvec, ff, cur_1b, nspin, nlorentz)
+
+        mom_in = fourvector(p1_4(1), p1_4(2), p1_4(3), p1_4(4))
+        mom_out = fourvector(pp1_4(1), pp1_4(2), pp1_4(3), pp1_4(4))
+        mom_spect = fourvector(p2_4(1), p2_4(2), p2_4(3), p2_4(4))
+        qvec = fourvector(q4(1), q4(2), q4(3), q4(4))
         call model%currents(pids_in, mom_in, nin, pids_out, mom_out, nout, pids_spect, mom_spect, nspect, qvec, ff, cur_2b, nspin, nlorentz)
 
 


### PR DESCRIPTION
There was an issue in which when using a Fortran model, the memory used by Achilles would continuously grow. This was a result of memory management between the C++ and Fortran side. This adds in the logic to clear that memory when it is no longer being used. This should resolve the issues with the memory leak.

Closes #132 