### PR TITLE
fix(cascade): Ensure cascade interactions are always kept

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -50,6 +50,11 @@ CPMAddPackage(
           "NuHepMC_CPPUtils_PYTHON_ENABLED OFF"
           "NuHepMC_CPPUtils_PROTOBUF_INTERFACE OFF"
 )
+# cpputils hardcodes -Werror, and the HepMC3 headers it bundles trigger
+# warnings on newer compilers; demote those back to warnings.
+if(TARGET nuhepmc_private_compile_options)
+    target_compile_options(nuhepmc_private_compile_options INTERFACE -Wno-error)
+endif()
 
 CPMAddPackage(
     NAME HighFive

--- a/src/Achilles/CMakeLists.txt
+++ b/src/Achilles/CMakeLists.txt
@@ -135,7 +135,7 @@ target_link_libraries(event_gen PUBLIC AchillesHepMC3 nuhepmc)
 endif()
 target_link_libraries(event_gen PRIVATE project_warnings
                                 PUBLIC physics mappers fortran_interface nuclear_models
-                                       AchillesCascadeInteractions) #fortran_interface
+                                       ${AchillesCascadeInteractionsLink}) #fortran_interface
 list(APPEND achilles_targets event_gen)
 
                             # pybind11_add_module(_achilles MODULE

--- a/src/Achilles/CascadeInteractions/CMakeLists.txt
+++ b/src/Achilles/CascadeInteractions/CMakeLists.txt
@@ -13,3 +13,17 @@ target_link_libraries(AchillesCascadeInteractions PRIVATE project_options projec
                                                   PUBLIC physics AchillesIntegrator)
 list(APPEND achilles_targets AchillesCascadeInteractions)
 set(achilles_targets ${achilles_targets} PARENT_SCOPE)
+
+# The interaction models in this library are only reachable through their static-initializer
+# self-registration with the InteractionFactory; no symbol in the library is referenced
+# directly. Linkers running with --as-needed (the default on e.g. Ubuntu and Fedora) therefore
+# drop the library from the consumer's runtime dependencies, its initializers never run, and
+# no cascade interactions are registered. Consumers must link via this variable, which pins
+# the library with --no-as-needed and restores the previous linker state afterwards.
+if(UNIX AND NOT APPLE)
+    set(AchillesCascadeInteractionsLink
+        "-Wl,--push-state,--no-as-needed" AchillesCascadeInteractions "-Wl,--pop-state"
+        PARENT_SCOPE)
+else()
+    set(AchillesCascadeInteractionsLink AchillesCascadeInteractions PARENT_SCOPE)
+endif()


### PR DESCRIPTION
Under certain operating systems, the cascade interactions were being dropped by a compiler flag being set by default.
This injects the flag to ensure they are not dropped by the compiler/linker.
