### PR TITLE
ci(pypi): Derive package version at build time

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,8 +13,60 @@ on:
       - main
 
 jobs:
+  version:
+    name: Compute package version
+    # Data releases (achilles-data-v*) fire this trigger too; never publish those.
+    if: >-
+      github.event_name != 'release' ||
+      startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_release: ${{ steps.version.outputs.is_release }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          # `git tag` below needs the full tag history
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            version="${RELEASE_TAG#v}"
+            is_release=true
+          else
+            # Nightly. The v[0-9]* glob excludes achilles-data-v* tags.
+            tags="$(git tag --list 'v[0-9]*' --sort=-v:refname)"
+            base="$(TAGS="$tags" python3 - <<'EOF'
+          import os, re
+          # Bump the minor of the newest final so PEP 440 orders the nightly
+          # 0.3.1 < 0.4.0.devYYYYMMDD < 0.4.0rc1 < 0.4.0; skip rc tags, no tags -> 0.1.0.
+          for tag in os.environ["TAGS"].splitlines():
+              match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag.strip())
+              if match:
+                  major, minor, _ = map(int, match.groups())
+                  print(f"{major}.{minor + 1}.0")
+                  break
+          else:
+              print("0.1.0")
+          EOF
+            )"
+            version="${base}.dev$(date -u +%Y%m%d)"
+            is_release=false
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "is_release=${is_release}" >> "$GITHUB_OUTPUT"
+          echo "Building version ${version} (release: ${is_release})"
+
   build_wheels:
     name: Build wheels for ${{ matrix.os }}
+    needs: [version]
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
@@ -38,6 +90,23 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Stamp version into pyproject.toml
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          python3 - <<'EOF'
+          import os, pathlib, re
+          version = os.environ["VERSION"]
+          path = pathlib.Path("pyproject.toml")
+          patched, count = re.subn(
+              r'(?m)^version = ".*"$', f'version = "{version}"', path.read_text(), count=1
+          )
+          if count != 1:
+              raise SystemExit("no [project] version line found in pyproject.toml")
+          path.write_text(patched)
+          print(f"pyproject.toml version -> {version}")
+          EOF
 
       # The build[uv] frontend needs uv on PATH
       - uses: astral-sh/setup-uv@v6
@@ -80,11 +149,30 @@ jobs:
 
   build_sdist:
     name: Build source distribution
+    needs: [version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Stamp version into pyproject.toml
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          python3 - <<'EOF'
+          import os, pathlib, re
+          version = os.environ["VERSION"]
+          path = pathlib.Path("pyproject.toml")
+          patched, count = re.subn(
+              r'(?m)^version = ".*"$', f'version = "{version}"', path.read_text(), count=1
+          )
+          if count != 1:
+              raise SystemExit("no [project] version line found in pyproject.toml")
+          path.write_text(patched)
+          print(f"pyproject.toml version -> {version}")
+          EOF
+
       - name: Build sdist
         run: pipx run build --sdist
       - uses: actions/upload-artifact@v4
@@ -93,18 +181,16 @@ jobs:
           path: dist/*.tar.gz
 
   pypi-publish:
-    name: Publish release to PyPI
-    needs: [build_wheels, build_sdist]
+    name: Publish ${{ needs.version.outputs.version }} to PyPI
+    needs: [version, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/achillesgen
     permissions:
       id-token: write
-    # TODO: Add in once the pipeline works
-    # if: github.event_name == 'release' && github.event.action == 'published'
-    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Pull requests build and test the wheels but must never publish.
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/download-artifact@v5
         with:
@@ -113,3 +199,6 @@ jobs:
           merge-multiple: true
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Same-day merges share a .devYYYYMMDD version; a release must never collide.
+          skip-existing: ${{ needs.version.outputs.is_release != 'true' }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -181,7 +181,7 @@ jobs:
           path: dist/*.tar.gz
 
   pypi-publish:
-    name: Publish ${{ needs.version.outputs.version }} to PyPI
+    name: Publish to PyPI
     needs: [version, build_wheels, build_sdist]
     runs-on: ubuntu-latest
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "AchillesGen"
-version = "0.3.0.dev20260710"
+# Local builds only; CI stamps the release tag or <next minor>.devYYYYMMDD.
+version = "0.4.0"
 requires-python = ">=3.10"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Problem

`pyproject.toml` carried a static `version`, so **every** push to `main` rebuilt and re-uploaded the same version and PyPI rejected the duplicate. The publish job had gone red on every merge.

Two adjacent paths also reached the publish step by mistake:

- **Data releases fire the PyPI trigger.** `achilles-data-v*` tags publish GitHub Releases, which fire `release: published` — so publishing a data set tried to upload to PyPI under a version named after a data tag. (`data-release.yml` already guards the opposite direction.)
- **`pull_request` had no guard at all** on the publish job, so PR runs reached it.

## Change

A new `version` job computes the version once and both build jobs stamp it into `pyproject.toml` before building. Computing it once matters: four build jobs each running `date` independently could disagree across a midnight rollover.

| Event | Version |
|---|---|
| `release` (`v*`) | the tag verbatim — `v0.4.0` → `0.4.0` |
| push to `main`, `workflow_dispatch` | `<next minor>.devYYYYMMDD` — `0.4.0.dev20260715` |
| `pull_request` | builds and tests; never publishes |

A release now matches its tag by construction, rather than by remembering to edit a file first.

### On the dev base

The nightly bumps the **minor** of the newest final tag rather than reusing it. Taking the latest release verbatim would give `0.3.1.dev20260715`, which PEP 440 sorts *below* the released `0.3.1` — making the nightly unreachable except by exact pin. The bump keeps the ordering right:

```
0.3.1  <  0.4.0.dev20260715  <  0.4.0rc1  <  0.4.0
```

Pre-release tags are skipped deliberately: `dev` sorts below an `rc` of the same version, so basing off the last final keeps a nightly correctly beneath an outstanding rc. (Note the current `0.3.0.dev20260710` had exactly the inversion above — it sat below the released `0.3.1`.)

Nightlies set `skip-existing` so same-day merges no-op instead of failing; releases leave it off and still fail loudly on a collision.

`pyproject.toml` is bumped to `0.4.0` as the next release target. It's a local-build placeholder only — CI stamps over it.

## Verification

The version step was extracted from the YAML and run against the real repo and synthetic tag layouts:

| Scenario | Result |
|---|---|
| real repo, push to `main` | `0.4.0.dev20260715` |
| real repo, release `v0.4.0` | `0.4.0` |
| no tags at all | `0.1.0.dev20260715` |
| only an `achilles-data-v*` tag | `0.1.0.dev20260715` (data tag excluded) |
| `v0.4.0rc1` outstanding | `0.4.0.dev20260715` (sorts below the rc) |
| after `v0.4.0` ships | `0.5.0.dev20260715` |

Also confirmed the stamping step patches the `[project]` version without touching the `test-command` line that also contains the word `version`.

**Not verified locally:** the workflow end-to-end on GitHub. The trigger gating and `needs`-skip propagation are reasoned from the YAML, not observed — the first merge to `main` will be the real test of the nightly path.

This closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)