### PR TITLE
fix(cascade): Resolve decays.yml using FindFile and allow user to set

### DIFF
--- a/include/Achilles/Cascade.hh
+++ b/include/Achilles/Cascade.hh
@@ -88,7 +88,8 @@ class Cascade {
     /// TODO: Should the ProbabilityType be part of the interaction class or the cascade class?
     Cascade() = default;
     Cascade(InteractionHandler, const ProbabilityType &, Algorithm, const InMedium &,
-            bool potential_prob = false, double dist = 0.03);
+            std::string_view decay_file = default_decay_file, bool potential_prob = false,
+            double dist = 0.03);
     Cascade(Cascade &&) = default;
     Cascade &operator=(Cascade &&) = default;
 
@@ -211,8 +212,7 @@ class Cascade {
     std::set<std::size_t> kickedIdxs;
     double distance{}, timeStep{}, currentTime{};
     InteractionHandler m_interactions{};
-    // TODO: Allow user to define externally which file to use
-    DecayHandler m_decays{"data/decays.yml"};
+    DecayHandler m_decays;
     std::function<double(double, double)> probability;
     std::function<size_t(Cascade *, size_t, Event &)> algorithm;
     Nucleus *m_nucleus;
@@ -242,7 +242,9 @@ template <> struct convert<achilles::Cascade> {
         auto potentialProp = node["PotentialProp"].as<bool>();
         auto distance = node["Step"].as<double>();
         auto algorithm = node["Algorithm"].as<achilles::Cascade::Algorithm>();
-        cascade = achilles::Cascade(std::move(handler), probType, algorithm, mediumType,
+        std::string_view decay_file = achilles::default_decay_file;
+        if(node["DecayFile"]) decay_file = node["DecayFile"].as<std::string_view>();
+        cascade = achilles::Cascade(std::move(handler), probType, algorithm, mediumType, decay_file,
                                     potentialProp, distance);
         return true;
     }

--- a/include/Achilles/DecayHandler.hh
+++ b/include/Achilles/DecayHandler.hh
@@ -14,6 +14,8 @@ namespace achilles {
 
 class Particle;
 
+static constexpr std::string_view default_decay_file = "data/decays.yml";
+
 struct DecayMode {
     double branching_ratio;
     size_t angular_mom;

--- a/src/Achilles/Beams.cc
+++ b/src/Achilles/Beams.cc
@@ -165,7 +165,8 @@ Spectrum::Spectrum(const YAML::Node &node) {
         m_delta_energy = m_max_energy - m_min_energy;
     } else if(node["ROOTHist"]) {
 #ifdef USE_ROOT
-        std::string filename = Filesystem::FindFlux(node["ROOTHist"]["File"].as<std::string>());
+        std::string filename =
+            Filesystem::FindFlux(node["ROOTHist"]["File"].as<std::string>(), "ROOTFlux");
         spdlog::trace("Reading flux file: {}", filename);
         TFile *file = new TFile(filename.c_str());
         TH1D *hist =

--- a/src/Achilles/Cascade.cc
+++ b/src/Achilles/Cascade.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "Achilles/System.hh"
 #include "spdlog/spdlog.h"
 
 #include "Achilles/Cascade.hh"
@@ -22,8 +23,10 @@
 using namespace achilles;
 
 Cascade::Cascade(InteractionHandler interactions, const ProbabilityType &prob, Algorithm alg,
-                 const InMedium &medium, bool potential_prop, double dist)
-    : distance(dist), m_interactions(std::move(interactions)), m_medium(medium),
+                 const InMedium &medium, std::string_view decay_file, bool potential_prop,
+                 double dist)
+    : distance(dist), m_interactions(std::move(interactions)),
+      m_decays(Filesystem::FindFile(std::string(decay_file), "Cascade")), m_medium(medium),
       m_potential_prop(potential_prop) {
     switch(alg) {
     case Algorithm::Base:

--- a/test/test_cascade.cc
+++ b/test/test_cascade.cc
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2018-2026 Achilles Developers
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "Achilles/DecayHandler.hh"
 #include "catch2/catch.hpp"
 #include "catch_utils.hh"
 #include "mock_classes.hh"
@@ -64,7 +65,8 @@ TEST_CASE("Evolve States: 1 nucleon", "[Cascade]") {
             .RETURN(5);
 
         achilles::Cascade cascade(std::move(interaction), mode, achilles::Cascade::Algorithm::Base,
-                                  achilles::Cascade::InMedium::None, true);
+                                  achilles::Cascade::InMedium::None, achilles::default_decay_file,
+                                  true);
         cascade.SetKicked(0);
         cascade.Evolve(event, &nucleus);
 
@@ -164,7 +166,8 @@ TEST_CASE("Evolve States: 3 nucleons", "[Cascade]") {
             .RETURN(5);
 
         achilles::Cascade cascade(std::move(interaction), mode, achilles::Cascade::Algorithm::Base,
-                                  achilles::Cascade::InMedium::None, true);
+                                  achilles::Cascade::InMedium::None, achilles::default_decay_file,
+                                  true);
         cascade.SetKicked(0);
         cascade.Evolve(event, &nucleus);
 


### PR DESCRIPTION
This enables the user to change were the decays for the cascade are loaded from. It also uses the FindFile code to look for the file in places other than the current working directory. This was an issue when running the python version downloaded from pypi. This should now be resolved.

This issue closes #153 